### PR TITLE
add metamagic for title, desc, keywords, etc.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'httparty'
 gem 'jbuilder', '~> 2.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
+gem 'metamagic' # manage html meta info
 gem 'omniauth'
 gem 'omniauth-github'
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    metamagic (3.1.7)
+      rails (>= 3.0.0)
     method_source (0.8.2)
     mime-types (2.6.1)
     mini_portile (0.6.2)
@@ -188,6 +190,7 @@ DEPENDENCIES
   httparty
   jbuilder (~> 2.0)
   jquery-rails
+  metamagic
   omniauth
   omniauth-github
   pg
@@ -201,3 +204,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.5

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -46,6 +46,10 @@ class Assignment < ActiveRecord::Base
     summary_items
   end
 
+    def to_s
+    "#{title} (#{assignment_type})"
+  end
+
   private
   def seed_submissions
     Student.all.each do |student|

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -50,4 +50,10 @@ class Submission < ActiveRecord::Base
     return query.join("+")
   end
 
+  def to_s
+    items_to_display = []
+    items_to_display << "#{student.name}'s" if student
+    items_to_display <<  %Q("#{self.assignment}")
+    items_to_display.join(" ")
+  end
 end

--- a/app/views/assignments/edit.html.erb
+++ b/app/views/assignments/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Edit Assignment</h1>
+<h1><%= title "Editing #{@assignment}" %></h1>
 
 <table>
   <thead>

--- a/app/views/assignments/outcomes.html.erb
+++ b/app/views/assignments/outcomes.html.erb
@@ -1,3 +1,5 @@
+<h1><%= title "Outcomes related Assignments" %></h1>
+
 <% @assignments.each do |assignment| %>
 <div class='assignment'>
   <h3><%= link_to assignment.title, assignment_path(assignment) %></h3><small>(<%= assignment.assignment_type %>)</small>

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -1,3 +1,4 @@
+<% meta title: @assignment %>
 <h1>
   <%= link_to_if @assignment.repo_url.present?, @assignment.title, @assignment.repo_url %>
   <span>(<%= "#{@assignment.summary_info.join(", ")})" %></span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Assignments</title>
+  <%= metamagic title: 'Assignments' %>
+
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application'%>
   <%= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.22.3/js/jquery.tablesorter.js" %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Students</h1>
+<h1><%= title "Students" %></h1>
 
 <ul>
   <% @students.each do |student| %>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -1,5 +1,4 @@
-
-<h1>Student: <%= @student.name %></h1>
+<h1><%= title @student.name %></h1>
 
 <h2>Submissions</h2>
 <table>

--- a/app/views/submissions/edit.html.erb
+++ b/app/views/submissions/edit.html.erb
@@ -1,2 +1,3 @@
+<h1><%= title "Editing #{@submission}" %></h1>
 <%= link_to "Preview", assignment_submission_path(@assignment, @submission) %>
 <%= render 'form' %>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -1,6 +1,5 @@
-<h2><%= @assignment.title %></h2>
-<h3>Submissions</h3>
 
 <table>
   <%= render partial: @submissions, locals: {header: :student_name} %>
 </table>
+<h1><%= title "Submissions for #{@assignment}" %></h1>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -1,2 +1,3 @@
 <br><%= link_to "&larr; Back".html_safe, "../" %>
+<h1><%= title "New submission for #{@assignment.title}" %></h1>
 <%= render "form" %>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,5 +1,5 @@
-<%= link_to "edit", edit_assignment_submission_path(@assignment,@submission) %>
-<h2><%= @submission.student.name %></h2>
+<h1><%= title "#{@submission}" %></h1>
+
 <table>
   <%= render partial: @submission, locals: {header: :assignment_name} %>
 </table>

--- a/readme.md
+++ b/readme.md
@@ -27,11 +27,11 @@ creates a new assignment. required parameters are:
 
 | Name | Type | Description |
 |---|---|---|
-| `title` | `string` | **Required.** The title of the assignment | 
-| `weekday` | `string` | **Required.** The weekday of the assignment of format w00d00 | 
+| `title` | `string` | **Required.** The title of the assignment |
+| `weekday` | `string` | **Required.** The weekday of the assignment of format w00d00 |
 | `repo_url` | `string` | **Required.** The git cloneable repository url of the assignment |
-| `due_date` | `string` | The due date of the assignment of format w00d00 | 
-| `rubric_url` | `string` | A link to the rubric of the assignment | 
+| `due_date` | `string` | The due date of the assignment of format w00d00 |
+| `rubric_url` | `string` | A link to the rubric of the assignment |
 
 ## Get a single assignment
 
@@ -42,7 +42,7 @@ GET /assignments/:id
 lists an assignment by both id and weekday value. As an example:
 
 ```
-http://api.wdidc.org/assignments/1 
+http://api.wdidc.org/assignments/1
 ```
 
 or
@@ -89,4 +89,5 @@ github_client_secret: "your client id"
 ```
 
 
-## Trivial Update
+## Managing Page Meta Info (title, description, keywords, etc)
+Assigning an appropriate title can come in handy for managing browser tabs (i.e. when you open all the assignments for your Squad).  We now have a documented process for managing page meta info, via [metamagic](https://github.com/lassebunk/metamagic).


### PR DESCRIPTION
- Used gem instead of custom method because:
  - there are many keys for meta info, wanted all supported in same fashion
  - now “our procedure” for supporting meta info is documented (by them).
- Using `to_s` as defacto display format.
